### PR TITLE
debhelper: fix conffiles corner case

### DIFF
--- a/dh_signobs
+++ b/dh_signobs
@@ -212,6 +212,12 @@ EOF
 				# generate rule set the version from the unsigned one
 				sed -i "s|#GENCONTROLMARKER|dh_gencontrol -p ${f%%/*} -- -v\$(shell cat debian/${f%%/*}.version); rm -f debian/${f%%/*}.version\\n\\t#GENCONTROLMARKER|" "../OTHER/$SOURCE_PKG/debian/rules"
 			fi
+
+			# special case: the conffiles lists the file in /etc, but it does
+			# get regenerated and it does not prune duplicates, triggering a
+			# Lintian error, so remove the old ones
+			echo "	rm -f debian/*.conffiles" >> "../OTHER/$SOURCE_PKG/debian/rules"
+
 			# finally copy the signed binary in the package build dir
 			# note that by convention bootloaders are renamed to .signed but
 			# kernel modules and images are not


### PR DESCRIPTION
Debian records the files installed in /etc in a metadata file called
conffiles. It is generated on every build and it does not prune
duplicates.
The debhelper copies the one from the unsigned package to the signed
package, causing a duplicate to appear and a Lintian error to be
raised. Clean them up to fix it.


Found this after deploying, one of the packages we have ships config files