### PR TITLE
rpm: properly forward dep flags

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -296,6 +296,9 @@ sub print_package {
 
 # /usr/include/rpm/rpmds.h
 my %deptypes = (
+	posttrans => (1 <<  5),
+	pretrans  => (1 <<  7),
+	interp => (1 <<  8),
 	pre    => (1 <<  9),
 	post   => (1 << 10),
 	preun  => (1 << 11),


### PR DESCRIPTION
rpmds.h says:
```C
RPMSENSE_POSTTRANS = (1 << 5),  /*!< %posttrans dependency */
RPMSENSE_PRETRANS  = (1 << 7),  /*!< Pre-transaction dependency. */
RPMSENSE_INTERP	   = (1 << 8),  /*!< Interpreter used by scriptlet. */
```

without this, kmp packages would differ in bit 5-8 compared to local builds
Diffs were mostly in rpm tags for /bin/sh and /bin/ldconfig

This fix was done as part of work on reproducible builds for openSUSE.

Fix was somewhat tested in https://build.opensuse.org/project/monitor/home:bmwiedemann:reproducible:pesign

pkgdiff showed for xtables-addons
```diff
comparing PROVIDES
-/bin/sh 0
-/bin/sh 1024
 /bin/sh 1280
-/bin/sh 2048
 /bin/sh 2304
 /bin/sh 288
-/bin/sh 4096
 /bin/sh 4352
 coreutils 0
```