### PR TITLE
Passthrough %license tag

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -345,6 +345,10 @@ my %filetypes = (
 	missingok => (1 << 3),
 	noreplace => (1 << 4),
 	ghost     => (1 << 6),
+	license   => (1 << 7),
+	readme    => (1 << 8),
+	pubkey    => (1 << 11),
+	artifact  => (1 << 12),
 );
 
 my %verifyflags = (
@@ -381,7 +385,9 @@ sub print_files {
 			}
 			$attrs .= "(" . join(",", @cfg_attrs) . ")" if @cfg_attrs;
 		}
-		$attrs .= "%doc " if $f->{flags} & $filetypes{doc};
+		for my $filetype (qw(doc license readme pubkey artifact)) {
+			$attrs .= "%$filetype " if $f->{flags} & $filetypes{$filetype};
+		}
 		if ($f->{flags} & $filetypes{ghost}) {
 			$attrs .= "%ghost ";
 			if (S_ISREG($f->{mode})) {


### PR DESCRIPTION
Passthrough `%license` file tag

This matters for openSUSE's `fwupd` package file `/usr/share/licenses/fwupd/COPYING`

and I also added 3 more bits from `rpm/lib/rpmfiles.h`

Without this patch, I got such a diff:
```diff
-/usr/share/licenses/fwupd/COPYING 0 (none) 100644 root root 0 4294967295
+/usr/share/licenses/fwupd/COPYING 128 (none) 100644 root root 0 4294967295
@@ -501
-/usr/share/licenses/fwupd/COPYING dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551 0
+/usr/share/licenses/fwupd/COPYING dc626520dcd53a22f727af3ee42c770e56c97a64fe3adb063799d8ab032fe551 128
```