### PR TITLE
Enable find_provides and requires

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -246,10 +246,6 @@ sub print_package {
 	if ($is_main) {
 		print SPEC "Name: $p->{name}\n";
 		print SPEC "Buildroot: $directory\n";
-		print SPEC "\%define _use_internal_dependency_generator 0\n";
-		print SPEC "\%define __find_provides %{nil}\n";
-		print SPEC "\%define __find_requires %{nil}\n";
-		print SPEC "\%define __find_supplements %{nil}\n";
 		if ($p->{nosource}) {
 			# We do not generate any no(src).rpm, but we want the
 			# %{sourcerpm} tag in the binary packages to match.
@@ -309,14 +305,20 @@ my %depflags = (
 	"<"    => (1 << 1),
 	">"    => (1 << 2),
 	"="    => (1 << 3),
+	find_requires => (1 << 14),
+	find_provides => (1 << 15),
 	rpmlib => (1 << 24),
+	config => (1 << 28),
 );
 
 sub print_deps {
 	my ($depname, $list) = @_;
 
+DEPLOOP:
 	foreach my $d (@$list) {
-		next if ($d->{flags} & $depflags{rpmlib});
+		for my $flag (qw(rpmlib config find_requires find_provides)) {
+			next DEPLOOP if ($d->{flags} & $depflags{$flag});
+		}
 
 		print SPEC $depname;
 		my @deptypes;


### PR DESCRIPTION
Enable find_provides and requires
to get automatic provides instead of manual ones
like the original package did

Without this patch,
`rpm -qpv --provides $rpm`
differed significantly between OBS build and local osc build.

```diff
filterdiff "rpm -qpv --provides" binaries*/fwupd-1.2.3-*.x86_64.rpm
--- filter/binaries/fwupd-1.2.3-42.6.x86_64.rpm
+++ filter/binaries.nachbau/fwupd-1.2.3-42.6.x86_64.rpm
@@ -1,4 +1,3 @@
-manual: config(fwupd) = 1.2.3-42.6
 config: config(fwupd) = 1.2.3-42.6
 manual: fwupd = 1.2.3-42.6
...
-manual: libfu_plugin_altos.so()(64bit)
-manual: libfu_plugin_amt.so()(64bit)
+auto: libfu_plugin_altos.so()(64bit)
+auto: libfu_plugin_amt.so()(64bit)
```

Fixes part of issue #9