### PR TITLE
Add support for kernel module compression

### DIFF
--- a/README
+++ b/README
@@ -36,3 +36,10 @@ Debian packages can use the dh-signobs debhelper to automate signing and
 repacking. Build-depend on dh-signobs and add --with signobs to the dh line
 in debian/rules to use the fully automated helper.
 Consult the dh_signobs manpage for more information.
+
+When BRP_PESIGN_COMPRESS_MODULE is passed, the script tries to compress the
+kernel modules at the repackaging phase. Currently only xz format is supported.
+For enable the compression feature, put the following along with
+BRP_PESIGN_FILES setup:
+
+export BRP_PESIGN_COMPRESS_MODULE="xz"

--- a/brp-99-pesign
+++ b/brp-99-pesign
@@ -57,6 +57,13 @@ if ! mkdir -p "$output"; then
 	echo "$0: warning: $output cannot be created, giving up" >&2
 	exit 0
 fi
+
+if test "${BRP_PESIGN_COMPRESS_MODULE}" = "xz"; then
+	pesign_repackage_compress="--compress xz"
+else
+	pesign_repackage_compress=""
+fi
+
 cert=$RPM_SOURCE_DIR/_projectcert.crt
 if test -e "$cert"; then
 	echo "Using signing certificate $cert"
@@ -66,6 +73,7 @@ else
 fi
 sed "
 	s:@NAME@:$RPM_PACKAGE_NAME:g
+	s:@PESIGN_REPACKAGE_COMPRESS@:$pesign_repackage_compress:g
 	/@CERT@/ {
 		r $cert
 		d

--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -30,6 +30,7 @@ my $directory;
 my $output = ".";
 my $cert_subpackage;
 my $kmp_basename;
+my $compress;
 my @rpms;
 
 $ENV{LC_ALL} = "en_US.UTF-8";
@@ -39,6 +40,7 @@ GetOptions(
 	"directory|d=s" => \$directory,
 	"output|o=s" => \$output,
 	"cert-subpackage|c=s" => \$cert_subpackage,
+	"compress|C=s" => \$compress,
 ) or die $USAGE;
 @rpms = @ARGV;
 if (!@rpms) {
@@ -417,7 +419,16 @@ sub print_files {
 			$attrs .= "%verify(not $verify_attrs) ";
 		}
 
-		print SPEC "$attrs " . quote($f->{name}) . "\n";
+		if ($compress eq "xz" &&
+		    $f->{name} =~ /\.ko$/ && S_ISREG($f->{mode})) {
+			system("xz", "-f", "-9", $path);
+			chmod($f->{mode}, $path . ".xz");
+			utime($f->{mtime}, $f->{mtime}, $path . ".xz");
+			print SPEC "$attrs " . quote($f->{name}) . ".xz\n";
+		} else {
+			print SPEC "$attrs " . quote($f->{name}) . "\n";
+		}
+
 		if (-e "$path.sig") {
 			print SPEC "$attrs " . quote($f->{name}) . ".sig\n";
 		}

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -145,7 +145,8 @@ for sig in "${sigs[@]}"; do
 	esac
 done
 popd
-/usr/lib/rpm/pesign/pesign-gen-repackage-spec --directory=%buildroot "${rpms[@]}"
+/usr/lib/rpm/pesign/pesign-gen-repackage-spec @PESIGN_REPACKAGE_COMPRESS@ \
+	--directory=%buildroot "${rpms[@]}"
 rpmbuild --define "%%buildroot %buildroot" --define "%%disturl $disturl" \
 	 --define "%%_builddir $PWD" \
 	 --define "%_suse_insert_debug_package %%{nil}" -bb repackage.spec


### PR DESCRIPTION
This adds the support for kernel module compression in
pesign-obs-integration infrastructure.  The kernel-binary spec needs
to pass $BRP_PESIGN_COMPRESS_KERNEL for enabling the compression.
Currently only "xz" is supported.

pesign-gen-repackage-spec received a new option --compress, which is
passed from pesign-repackage.spec, where brp-99-pesign enables it per
the variable above.

With --compress option, pesign-gen-repackage-spec script just
compresses the kernel object at the last repackaging phase.

Bugzilla: http://bugzilla.suse.com/show_bug.cgi?id=1135854
Signed-off-by: Takashi Iwai <tiwai@suse.de>