### PR TITLE
also sign the s390x kernel image just with sign-file

### DIFF
--- a/brp-99-pesign
+++ b/brp-99-pesign
@@ -117,7 +117,12 @@ for f in "${files[@]}"; do
 	mkdir -p "${dest%/*}"
 	case "$f" in
 	./boot/* | *.efi)
-		pesign --certdir="$nss_db" -i "$f" -E $dest
+		if [ -f /usr/bin/pesign ]; then
+			pesign --certdir="$nss_db" -i "$f" -E $dest
+		else
+			# Non PE architectures like s390x
+			cp "$f" "$dest"
+		fi
 		;;
 	*)
 		cp "$f" "$dest"

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -148,6 +148,9 @@ for sig in "${sigs[@]}"; do
 			/usr/lib/rpm/pesign/gen-hmac -r %buildroot "/${sig%.sig}"
 		fi
 		;;
+	*stage3.bin.sig)
+		/usr/lib/rpm/pesign/kernel-sign-file -i pkcs7 -s "$sig" sha256 "$cert" "$f"
+		;;
 	*)
 		echo "Warning: unhandled signature: $sig" >&2
 	esac

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -130,6 +130,8 @@ for sig in "${sigs[@]}"; do
 		/usr/lib/rpm/pesign/kernel-sign-file -i pkcs7 -s "$sig" sha256 "$cert" "$f"
 		;;
 	/boot/* | *.efi.sig)
+%ifarch %ix86 x86_64 aarch64 %arm
+		# PE style signature injection
 		infile=${sig%.sig}
 		cpio -i --to-stdout ${infile#./} <%_sourcedir/@NAME@.cpio.rsasign > ${infile}.sattrs
 		test -s ${infile}.sattrs || exit 1
@@ -142,6 +144,10 @@ for sig in "${sigs[@]}"; do
 		    echo "hash mismatch error: $ohash $nhash"
 		    exit 1
 		fi
+%else
+		# appending to the file itself, e.g. for s390x.
+		/usr/lib/rpm/pesign/kernel-sign-file -i pkcs7 -s "$sig" sha256 "$cert" "$f"
+%endif
 		# Regenerate the HMAC if it exists
 		hmac="${f%%/*}/.${f##*/}.hmac"
 		if test -e "$hmac"; then


### PR DESCRIPTION
This also handles signing the s390x kernel image
with sign-file only.

I use presence chechking of pesign in the brp, and %ifarch branches in the repackage spec.in