### PR TITLE
Compress kernel modules in batch and in parallel

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -369,6 +369,7 @@ my %verifyflags = (
 
 sub print_files {
 	my $files = shift;
+	my @tocompress;
 
 	for my $f (@$files) {
 		my $path = "$directory/$f->{name}";
@@ -423,9 +424,9 @@ sub print_files {
 
 		if ($compress eq "xz" &&
 		    $f->{name} =~ /\.ko$/ && S_ISREG($f->{mode})) {
-			system("xz", "-f", "-9", $path);
-			chmod($f->{mode}, $path . ".xz");
-			utime($f->{mtime}, $f->{mtime}, $path . ".xz");
+			chmod($f->{mode}, $path);
+			utime($f->{mtime}, $f->{mtime}, $path);
+			push(@tocompress, $path);
 			print SPEC "$attrs " . quote($f->{name}) . ".xz\n";
 		} else {
 			print SPEC "$attrs " . quote($f->{name}) . "\n";
@@ -434,6 +435,15 @@ sub print_files {
 		if (-e "$path.sig") {
 			print SPEC "$attrs " . quote($f->{name}) . ".sig\n";
 		}
+	}
+
+	if ($#tocompress >= 0) {
+		my $m = "$output/modulelist.txt";
+		open(M, '>', $m) or die "$m: $!\n";
+		print M join("\n", @tocompress);
+		close(M);
+		system("xargs -a $m -t -P 4 -n 1 xz -f");
+		unlink($m);
 	}
 }
 


### PR DESCRIPTION
currently we're sequentially compressing the modules using
xz -9. In testing against the kernel 5.8 in Tumbleweed, there
was very little compression size difference between xz -9 and xz,
however almost a 40% runtime performance improvement.

Also running in 4 jobs in parallel (instead of using xz -threads)
improves speed quite a bit. Last but not least wrapping
the invocations via "xargs -t" ensures that there is a constant
stream of logging output that prevents the build service
from killing the job as it is considered stalled.

Signed-off-by: Dirk Mueller <dirk@dmllr.de>