### PR TITLE
brp-99-pesign: fix that the signature of shim be broken

### DIFF
--- a/brp-99-pesign
+++ b/brp-99-pesign
@@ -120,7 +120,7 @@ for f in "${files[@]}"; do
 	dest="$archive_dir/$f"
 	mkdir -p "${dest%/*}"
 	case "$f" in
-	./boot/* | *.efi.sig | */lib/modules/*/vmlinu[xz] | */lib/modules/*/[Ii]mage | */lib/modules/*/z[Ii]mage)
+	./boot/* | *.efi | */lib/modules/*/vmlinu[xz] | */lib/modules/*/[Ii]mage | */lib/modules/*/z[Ii]mage)
 		if [ -f /usr/bin/pesign ]; then
 			pesign --certdir="$nss_db" -i "$f" -E $dest
 		else


### PR DESCRIPTION
The 911a77299ed change broke the signature of shim. Using the following
process can check the signature of shim:

    pesign -e shim-opensuse.efi.sig -i shim-opensuse.efi
    openssl asn1parse -inform der -in shim-opensuse.efi.sig

The above command shows:

> openssl asn1parse -inform der -in shim-opensuse.efi.sig  | less
139740672369088:error:0D07209B:asn1 encoding routines:ASN1_get_object:too long:crypto/asn1/asn1_lib.c:91:
    0:d=0  hl=5 l=926808 cons: SEQUENCE
    5:d=1  hl=2 l=   9 prim: OBJECT            :pkcs7-signedData
...
 1252:d=6  hl=2 l=   0 prim: EOC
 1254:d=6  hl=2 l=   0 prim: cont [ 0 ]
 1256:d=6  hl=2 l=   0 prim: EOC
Error in encoding

The PKCS#7 format is broken that it can not pass the openQA testing.

Signed-off-by: Lee, Chun-Yi <jlee@suse.com>