### PR TITLE
Do not repackage -64bit/aarch64_ilp32

### DIFF
--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -67,7 +67,7 @@ for rpm in %_sourcedir/*.rpm; do
 	# bitness => skip)
 	case "$(rpm -qp --qf '%%{name}/%%{arch}' "$rpm")" in
 	*-32bit/x86_64 | *-32bit/s390x | *-32bit/ppc64 | \
-	*-64bit/ppc | *-x86/ia64)
+	*-64bit/aarch64_ilp32 | *-64bit/ppc | *-x86/ia64)
 		mkdir -p "%_topdir/OTHER"
 		cp "$rpm" "$_"
 		continue


### PR DESCRIPTION
This is to fix `openSUSE:Factory:ARM/systemd` which fails with:
```
[   60s] ... running 50-check-packaged-twice
[   60s] found conflict of libsystemd0-250.4-5.2.aarch64 with libsystemd0-64bit-250.4-5.2.aarch64:
[   60s]   - /usr/lib64/libsystemd.so.0.33.0
[   60s] found conflict of libudev1-250.4-5.2.aarch64 with libudev1-64bit-250.4-5.2.aarch64:
[   60s]   - /usr/lib64/libudev.so.1.7.3
[   60s] found conflict of nss-myhostname-250.4-5.2.aarch64 with nss-myhostname-64bit-250.4-5.2.aarch64:
[   60s]   - /usr/lib64/libnss_myhostname.so.2
[   60s] found conflict of systemd-250.4-5.2.aarch64 with systemd-64bit-250.4-5.2.aarch64:
[   60s]   - /usr/lib64/security/pam_systemd.so
```