### PR TITLE
Fix %attr issues

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -416,8 +416,10 @@ sub print_files {
 			$attrs .= "\%dir ";
 			utime($f->{mtime}, $f->{mtime}, $path);
 		}
-		$attrs .= sprintf('%%attr(%04o, %s, %s) ', ($f->{mode} & 0777),
-			$f->{owner}, $f->{group});
+		unless (-l "$path") {
+			$attrs .= sprintf('%%attr(%04o, %s, %s) ', ($f->{mode} & 07777),
+				$f->{owner}, $f->{group});
+		}
 		if ($f->{flags} & $filetypes{config}) {
 			$attrs .= "%config ";
 			my @cfg_attrs;


### PR DESCRIPTION
1) Avoid assigning %attr's to symlinks which causes rpmbuild spam
2) Change perms mask to 07777 to ensure SUID/SGID is copied over