### PR TITLE
Fix %attr issues

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -416,8 +416,6 @@ sub print_files {
 			$attrs .= "\%dir ";
 			utime($f->{mtime}, $f->{mtime}, $path);
 		}
-		$attrs .= sprintf('%%attr(%04o, %s, %s) ', ($f->{mode} & 0777),
-			$f->{owner}, $f->{group});
 		if ($f->{flags} & $filetypes{config}) {
 			$attrs .= "%config ";
 			my @cfg_attrs;
@@ -447,6 +445,10 @@ sub print_files {
 				make_path(dirname($path));
 				symlink($f->{target}, $path);
 			}
+		}
+		unless (S_ISLNK($f->{mode})) {
+			$attrs .= sprintf('%%attr(%04o, %s, %s) ', ($f->{mode} & 07777),
+				$f->{owner}, $f->{group});
 		}
 		# mtime of symlinks is also not preserved by cpio
 		if (S_ISLNK($f->{mode})) {


### PR DESCRIPTION
1) Avoid assigning %attr's to symlinks which causes rpmbuild spam
2) Change perms mask to 07777 to ensure SUID/SGID is copied over