### PR TITLE
pesign-gen-repackage-spec: fix the filename issue in the scripts of g…

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -556,7 +556,8 @@ if ($cert_subpackage) {
 				print STDERR "warning: Ignoring $directory/$certdir/$cert (no .crt suffix)\n";
 				next;
 			}
-			$certs .= " $certdir/$cert";
+			$cert =~ s{\.[^.]+$}{};
+			$certs .= " $cert";
 		}
 	}
 	if (!$certs) {


### PR DESCRIPTION
…enerated ueficert package

When using modsign-repackage, the post script in the generated *-ueficert-*.rpm package can not enroll certificate to MOK through mokutil. It shows:

Preparing...                          ################################# [100%]
Updating / installing...
   1:drbd-kernel-ueficert-9.2.0~rc.3-1################################# [100%]
Failed to get file status, /etc/uefi/certs//etc/uefi/certs/8505A847.crt.crt
Failed to import /etc/uefi/certs//etc/uefi/certs/8505A847.crt.crt
warning: %post(drbd-kernel-ueficert-9.2.0~rc.3-1.x86_64) scriptlet failed, exit status 255

The reason is that pesign-gen-repackage-spec generates /etc/uefi/certs/*.crt filename to -ueficert scripts in repackage.spec. But suse-module-tools/kernel-scriptlets/cert-script already applies /etc/uefi/certs/ and .crt extension. It causes redundant path and extension be generated to *-ueficert-*.rpm.

This patch removed the /etc/uefi/certs path and .crt extension before pesign-gen-repackage-spec print it to repackage.spec. (bsc#1195805)

Signed-off-by: Lee, Chun-Yi <jlee@suse.com>