### PR TITLE
Create changes file for reproducible build

### DIFF
--- a/brp-99-pesign
+++ b/brp-99-pesign
@@ -122,6 +122,15 @@ sed "
 	}
 " /usr/lib/rpm/pesign/pesign-repackage.spec.in >"$output/pesign-repackage.spec"
 
+date="$(LANG=C date --utc --date "@${SOURCE_DATE_EPOCH:-$(date +%s)}" '+%a %b %d %H:%M:%S %Z %Y')"
+cat <<EOF >"$output/pesign-repackage.changes"
+-------------------------------------------------------------------
+$date - openSUSE <packaging@lists.opensuse.org>
+
+- automatically generated
+
+EOF
+
 for rpmlintrc in $RPM_SOURCE_DIR/*rpmlintrc; do
 	if test -e "$rpmlintrc"; then
 		cp "$rpmlintrc" "$output/"


### PR DESCRIPTION
otherwise rpm/obs can not extract a source code date to use as SOURCE_DATE_EPOCH for the build time. Then the build with pesign-repackage.spec would fail.

See also https://github.com/openSUSE/post-build-checks/pull/62