### PR TITLE
Export also a VCS tag

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -164,7 +164,7 @@ my %sense2tag = (
 
 # tags which are printed verbatim in the specfile
 my @simple_tags = qw(epoch version release license group summary packager vendor
-                     url distribution);
+                     url vcs distribution);
 my @payload_tags = qw(payloadcompressor payloadflags);
 
 sub load_package {


### PR DESCRIPTION
it is used to report the git repository of the package sources for git based builds.