### PR TITLE
Quote % signs in scripts

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -311,7 +311,7 @@ sub print_script {
 	return unless $script->{script};
 	open(my $fh, '>', "$output/$file")
 		or die "$output/$file: $!\n";
-	print $fh $script->{script};
+	print $fh quote($script->{script});
 	close($fh);
 	print SPEC " -f $file";
 }


### PR DESCRIPTION
fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1228091 where in systemd, comments with `%%pre` were mistaken for `%pre` .

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.