### PR TITLE
Make the repackage work with rpm-4.20

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -658,6 +658,16 @@ if ($cert_subpackage) {
 	$template =~ s/\@CERTS\@/$certs/g;
 	print SPEC $template;
 }
+
+print SPEC <<"EOF";
+%if "%buildroot" != "$directory"
+%install
+rmdir %buildroot
+ln -sf $directory %buildroot
+%endif
+
+EOF
+
 print SPEC "\%changelog\n";
 print SPEC quote($packages{$main_name}->{changelog});
 close(SPEC);

--- a/pesign-obs-integration.changes
+++ b/pesign-obs-integration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Dec 17 11:11:32 CET 2024 - mls@suse.de
+
+- Add workaround to make the repackage work with rpm-4.20
+
+-------------------------------------------------------------------
 Mon Dec 21 03:50:35 UTC 2020 - Gary Ching-Pang Lin <glin@suse.com>
 
 - Update to version 10.2:


### PR DESCRIPTION
Rpm-4.20 no longer allows to redefine the buildroot. As a workaround, we add a %install section that replaces the buildroot with a symbolic link pointing to the correct directory.