### PR TITLE
Fix repackaging of scriptlets with rpm-4.20

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -664,6 +664,7 @@ print SPEC <<"EOF";
 %install
 rmdir %buildroot
 ln -sf $directory %buildroot
+%{?_top_builddir:%global buildsubdir ..}
 %endif
 
 EOF

--- a/pesign-obs-integration.changes
+++ b/pesign-obs-integration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Dec 20 11:10:01 CET 2024 - mls@suse.de
+
+- Fix repackaging of scriptlets with rpm-4.20
+
+-------------------------------------------------------------------
 Tue Dec 17 11:11:32 CET 2024 - mls@suse.de
 
 - Add workaround to make the repackage work with rpm-4.20


### PR DESCRIPTION
rpm-4.20 always adds a subdirectory to the builddir, so create a symlink to ".." so that the scriptlets are found.