### PR TITLE
Move the rpm-420 compatibility section from %install to %build

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -661,7 +661,7 @@ if ($cert_subpackage) {
 
 print SPEC <<"EOF";
 %if "%buildroot" != "$directory"
-%install
+%build
 rmdir %buildroot
 ln -sf $directory %buildroot
 %{?_top_builddir:%global buildsubdir ..}

--- a/pesign-obs-integration.changes
+++ b/pesign-obs-integration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Dec 21 11:51:24 CET 2024 - mls@suse.de
+
+- Move the rpm-420 compatibility section from %install to %build
+
+-------------------------------------------------------------------
 Fri Dec 20 11:10:01 CET 2024 - mls@suse.de
 
 - Fix repackaging of scriptlets with rpm-4.20


### PR DESCRIPTION
%install triggers the run of the brp scripts and debuginfo generation for some reason.