### PR TITLE
Add BRP_PESIGN_PACKAGES to filter package(s) to repack

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ export BRP_PESIGN_FILES='pattern...'
 BuildRequires: pesign-obs-integration
 ```
 
+BRP_PESIGN_PACKAGES can optionally be defined to restrict repacking to a subset
+of packages of choice.
+
 Debian packages need to add the following line to the Source stanza in the
 debian/control file, which will add "Obs: needssslcertforbuild" to the generated
 .dsc file:

--- a/brp-99-pesign
+++ b/brp-99-pesign
@@ -26,11 +26,19 @@ files="*.ko"
 if test -n "${BRP_PESIGN_FILES+x}"; then
 	files=${BRP_PESIGN_FILES}
 fi
+packages=
+if test -n "${BRP_PESIGN_PACKAGES+x}"; then
+	packages=${BRP_PESIGN_PACKAGES}
+fi
 output=
 while test $# -gt 0; do
 	case "$1" in
 	--files)
 		files=$2
+		shift 2
+		;;
+	--packages)
+		packages=$2
 		shift 2
 		;;
 	--output)
@@ -116,6 +124,7 @@ sed "
 	s:@PESIGN_GRUB_RESERVATION@:$pesign_grub_reservation:g
 	s:@PESIGN_REPACKAGE_COMPRESS@:$pesign_repackage_compress:g
 	s:@PESIGN_LOAD_SPEC_MACROS@:$spec_macros:g
+	s:@PESIGN_PACKAGES@:$packages:g
 	/@CERT@/ {
 		r $cert
 		d

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -49,6 +49,7 @@ export BRP_PESIGN_FILES=""
 
 pushd %buildroot
 disturl=
+rpms_filter=@PESIGN_PACKAGES@
 rpms=()
 for rpm in %_sourcedir/*.rpm; do
 	case "$rpm" in
@@ -73,6 +74,12 @@ for rpm in %_sourcedir/*.rpm; do
 		cp "$rpm" "$_"
 		continue
 	esac
+	# If the caller specified a set of packages to repack, skip everything else
+	if [[ -n "$rpms_filter" && ! "$rpm" =~ "$rpms_filter" ]]; then
+		mkdir -p "%_topdir/OTHER"
+		cp "$rpm" "$_"
+		continue
+	fi
 	rpm2cpio "$rpm" | cpio -idm
 	d=$(rpm -qp --qf '%%{disturl}' "$rpm")
 	if test -z "$disturl"; then


### PR DESCRIPTION
Currently pesign-obs-integration unpacks and repacks all RPMs being built. This creates a lot of movement, and in large source packages takes quite a few resources. Add an optional parameter to manually select which package to unpack and repack, and copy everything else as-is.

I am trying to get the Fedora spec + build of systemd-boot to get signed on OBS, and debugging as it doesn't work. Reducing the churn/output/work is nice as it helps narrow down the issue.