### PR TITLE
repackage spec: mozilla-nss-tools is for SUSE distros, on Fedora/etc it's nss-tools

### DIFF
--- a/pesign-obs-integration.spec
+++ b/pesign-obs-integration.spec
@@ -38,7 +38,9 @@ Requires:       nss-tools
 %endif
 Requires:       openssl
 # suse-module-tools <= 15.0.10 contains modsign-verify
+%if 0%{?suse_version}
 Requires:       suse-module-tools >= 15.0.10
+%endif
 %ifarch %{ix86} x86_64 ia64 aarch64 %{arm} riscv64
 Requires:       pesign
 %endif

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -25,7 +25,12 @@
 Name:           pesign-repackage
 Version:        1.0
 Release:        1
-BuildRequires:  openssl mozilla-nss-tools
+BuildRequires:  openssl
+%if 0%{?suse_version}
+BuildRequires:  mozilla-nss-tools
+%else
+BuildRequires:  nss-tools
+%endif
 %ifarch %ix86 x86_64 ia64
 BuildRequires:  pesign
 %endif


### PR DESCRIPTION
Same as 36ec20ab37cab8361a80dfd2210b8a8cbb70be55