### PR TITLE
Use pesign for signing on loongarch64

### DIFF
--- a/pesign-obs-integration.spec
+++ b/pesign-obs-integration.spec
@@ -41,7 +41,7 @@ Requires:       openssl
 %if 0%{?suse_version}
 Requires:       suse-module-tools >= 15.0.10
 %endif
-%ifarch %{ix86} x86_64 ia64 aarch64 %{arm} riscv64
+%ifarch %{ix86} x86_64 ia64 aarch64 %{arm} riscv64 loongarch64
 Requires:       pesign
 %endif
 

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -170,7 +170,7 @@ for sig in "${sigs[@]}"; do
 		rm -f "$f.p7s" "$f.p7sd" "$f.orig"
 		;;
 	/boot/* | *.efi.sig | */lib/modules/*/vmlinu[xz].sig | */lib/modules/*/[Ii]mage.sig | */lib/modules/*/z[Ii]mage.sig)
-%ifarch %ix86 x86_64 aarch64 %arm riscv64
+%ifarch %ix86 x86_64 aarch64 %arm riscv64 loongarch64
 		# PE style signature injection
 		infile=${sig%.sig}
 		cpio -i --to-stdout ${infile#./} <%_sourcedir/@NAME@.cpio.rsasign > ${infile}.sattrs


### PR DESCRIPTION
pesign build is enabled for loongarch64:
https://build.opensuse.org/request/show/1248911