### PR TITLE
More fixes for Fedora/CentOS builds

### DIFF
--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -688,7 +688,7 @@ if ($cert_subpackage) {
 print SPEC <<"EOF";
 %if "%buildroot" != "$directory"
 %build
-rmdir %buildroot
+rmdir %buildroot || true
 ln -sf $directory %buildroot
 %{?_top_builddir:%global buildsubdir ..}
 %endif

--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -647,6 +647,12 @@ for my $p (values(%packages)) {
 $kmp_basename = $main_name unless $kmp_basename;
 
 open(SPEC, '>', "$output/repackage.spec") or die "$output/repackage.spec: $!\n";
+print SPEC <<"EOF";
+%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
+%global debug_package %{nil}
+%endif
+
+EOF
 print_package($packages{$main_name}, 1);
 for my $name (sort(keys(%packages))) {
 	next if $name eq $main_name;

--- a/pesign-obs-integration.spec
+++ b/pesign-obs-integration.spec
@@ -17,7 +17,7 @@
 # needssslcertforbuild
 
 
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
 %global debug_package %{nil}
 %endif
 

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -237,11 +237,11 @@ popd
 /usr/lib/rpm/pesign/pesign-gen-repackage-spec @PESIGN_REPACKAGE_COMPRESS@ @PESIGN_LOAD_SPEC_MACROS@ \
 	--directory=%buildroot "${rpms[@]}"
 
-# For some reason in Fedora builds the directory structure is different from SUSE,
+# For some reason in Fedora/CentOS builds the directory structure is different from SUSE,
 # which breaks repacking. Copy the package content to the buildroot that is actually used.
 # Also all the usual tricks to disable the debug package fail, and the build fails due to
 # the 'Empty files file <...>/debugsourcefiles.list' error. Delete the specpart to bypass it.
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
 	echo "%%install" >>repackage.spec
 	echo "cp -r %buildroot/* %%buildroot" >>repackage.spec
 	echo "rm -f %buildroot/../SPECPARTS/rpm-debuginfo.specpart" >>repackage.spec


### PR DESCRIPTION
Same as the existing fixes, mostly around debug files. With these changes, the build and signing steps work again with latest master.