### PR TITLE
Fix file collisions and preserve `RemovePathPostfixes` behavior during repackaging

### DIFF
--- a/modsign-repackage
+++ b/modsign-repackage
@@ -104,7 +104,16 @@ for rpm; do
 		cp "$rpm" "$_"
 		continue
 	esac
-	rpm2cpio "$rpm" | (cd "$buildroot"; cpio -idm --quiet) || exit
+	# To avoid conflict with duplicate installed file use suffix and
+	# RemovePathPostfixes from RPM macros.
+	pkg_name=$(rpm -qp --qf '%{name}' "$rpm")
+	mkdir -p "$workdir/tmp_extract"
+	rpm2cpio "$rpm" | cpio -idm -D "$workdir/tmp_extract" --quiet || exit
+	find "$workdir/tmp_extract" -depth ! -type d -print0 | while IFS= read -r -d '' f; do
+		mv "$f" "${f}.${pkg_name}"
+	done
+	cp -a "$workdir/tmp_extract"/. "$buildroot/"
+	rm -rf "$workdir/tmp_extract"
 	d=$(rpm -qp --qf '%{disturl}' "$rpm")
 	if test -z "$disturl"; then
 		disturl=$d
@@ -120,14 +129,15 @@ echo "Signing kernel modules..."
 if test ! -e "$cert.pub"; then
 	openssl x509 -in "$cert" -inform DER -pubkey -noout > "$cert.pub"
 fi
-for module in $(find "$buildroot" -type f -name '*.ko' -printf '%P\n'); do
+for module in $(find "$buildroot" -type f -name '*.ko.*' -printf '%P\n'); do
+	orig_module=$(echo "$module" | sed -r 's/\.ko\.[^/]+$/.ko/')
 	if test -n "$key"; then
 		/usr/lib/rpm/pesign/kernel-sign-file \
 			-i pkcs7 sha256 "$key" "$cert" "$buildroot/$module"
 	else
-		raw_sig="$sig_dir/$module.sig"
+		raw_sig="$sig_dir/$orig_module.sig"
 		if test ! -e "$raw_sig"; then
-			echo "$module.sig not found in $sig_dir" >&2
+			echo "$orig_module.sig not found in $sig_dir" >&2
 			exit 1
 		fi
 		ver_err=$(openssl rsautl -verify -inkey "$cert.pub" -pubin -in "$raw_sig" 2>&1 | grep -i error)

--- a/pesign-gen-repackage-spec
+++ b/pesign-gen-repackage-spec
@@ -347,6 +347,7 @@ sub print_package {
 	if ($is_main) {
 		print SPEC "\%{load:\%_sourcedir/$macros_file}\n" if $macros_file ne "";
 		print SPEC "Name: $p->{name}\n";
+		print SPEC "RemovePathPostfixes: .$p->{name}\n";
 		print SPEC "Buildroot: $directory\n";
 		if ($p->{nosource}) {
 			# We do not generate any no(src).rpm, but we want the
@@ -357,6 +358,7 @@ sub print_package {
 		}
 	} else {
 		print SPEC "\%package -n $p->{name}\n";
+		print SPEC "RemovePathPostfixes: .$p->{name}\n";
 	}
 	for my $tag (@simple_tags) {
 		next if $p->{$tag} eq "";
@@ -407,7 +409,7 @@ sub print_package {
 	}
 	if ($p->{files}) {
 		print SPEC "\%files -n $p->{name}\n";
-		print_files($p->{files});
+		print_files($p->{name}, $p->{files});
 	}
 	print SPEC "\n";
 }
@@ -490,6 +492,7 @@ my %verifyflags = (
 );
 
 sub print_files {
+    my $pkg_name = shift;
 	my $files = shift;
 	my @tocompress;
 	my $compress_ext = "";
@@ -509,12 +512,17 @@ sub print_files {
 	}
 
 	for my $f (@$files) {
-		my $path = "$directory/$f->{name}";
+		my $is_dir = S_ISDIR($f->{mode});
+		my $suffixed_name = $is_dir ? $f->{name} : $f->{name} . "." . $pkg_name;
+		my $path = "$directory/$suffixed_name";
 		my $attrs = "";
 		# Fix mtime of directories, which cpio -idm fails to preserve
-		if (S_ISDIR($f->{mode})) {
+		if ($is_dir) {
 			$attrs .= "\%dir ";
 			utime($f->{mtime}, $f->{mtime}, $path);
+		} else {
+			# files are suffixed
+			$path = "$directory/$f->{name}.${pkg_name}";
 		}
 		if ($f->{flags} & $filetypes{config}) {
 			$attrs .= "%config ";
@@ -575,13 +583,15 @@ sub print_files {
 			chmod($f->{mode}, $path);
 			utime($f->{mtime}, $f->{mtime}, $path);
 			push(@tocompress, $path);
-			print SPEC "$attrs " . quote_fn($f->{name} . $compress_ext) . "\n";
+			print SPEC "$attrs " . quote_fn($suffixed_name . $compress_ext) . "\n";
 		} else {
-			print SPEC "$attrs " . quote_fn($f->{name}) . "\n";
+			print SPEC "$attrs " . quote_fn($suffixed_name) . "\n";
 		}
 
-		if (-e "$path.sig") {
-			print SPEC "$attrs " . quote_fn($f->{name} . ".sig") . "\n";
+		my $sig_name = $f->{name} . ".sig";
+		my $suffixed_sig_name = $is_dir ? $sig_name : $sig_name . "." . $pkg_name;
+		if (-e "$directory/$suffixed_sig_name") {
+			print SPEC "$attrs " . quote_fn($suffixed_sig_name) . "\n";
 		}
 	}
 

--- a/pesign-repackage.spec.in
+++ b/pesign-repackage.spec.in
@@ -85,7 +85,13 @@ for rpm in %_sourcedir/*.rpm; do
 		cp "$rpm" "$_"
 		continue
 	fi
-	rpm2cpio "$rpm" | cpio -idm
+    mkdir -p "tmp_extract"
+	rpm2cpio "$rpm" | cpio -idm -D "tmp_extract" || exit
+	find "tmp_extract" -depth ! -type d -print0 | while IFS= read -r -d '' f; do
+		mv "$f" "${f}.${pkg_name}"
+	done
+	cp -a "tmp_extract"/. "./"
+	rm -rf "tmp_extract"
 	d=$(rpm -qp --qf '%%{disturl}' "$rpm")
 	if test -z "$disturl"; then
 		disturl=$d


### PR DESCRIPTION
## Description
This submission fixes a bug in the `modsign-repackage` workflow where files from different subpackages sharing the same installation path overwrite each other during extraction, effectively breaking the functionality of the `RemovePathPostfixes` RPM macro. See #79 

## Root Cause
When the `needssslcertforbuild` feature is active, `modsign-repackage` extracts the contents of all generated RPMs into a single, shared `buildroot` directory using `cpio`. 

Because `cpio` blindly extracts files to their defined paths, if two packages provide a file at the exact same path, the file from the last extracted RPM silently overwrites the previous one. When `pesign-gen-repackage-spec` generates the new `repackage.spec`, it packages this single, overwritten binary into *both* subpackages. As a result, the standalone binary is lost and replaced by the main binary.

## Resolution
To prevent `cpio` from clobbering overlapping files, this fix leverages the very macro that was being broken: `RemovePathPostfixes`.

1. **Safely Extracting Files (`modsign-repackage`):** Instead of piping `rpm2cpio` directly into the shared `buildroot`, each RPM is now extracted into a temporary directory. We then append the subpackage name as a suffix to all non-directory files (e.g., `/usr/bin/toto` becomes `/usr/bin/toto.toto-standalone`) before moving them into the shared `buildroot`.
2. **Adapting the Signing Loop (`modsign-repackage`):** The kernel module signing loop, which previously searched for `*.ko`, has been updated to search for `*.ko.*`. It safely strips the temporary package suffix to locate the correct raw signatures before executing `kernel-sign-file`.
3. **Updating the Generated Spec (`pesign-gen-repackage-spec`):** The Perl script has been updated to inject `RemovePathPostfixes: .%{pkg_name}` into the header of every generated package and subpackage. 
4. **Mapping the `%files` list (`pesign-gen-repackage-spec`):** The script now correctly outputs the suffixed filenames into the `%files` section. 

## Impact
When `rpmbuild` runs the final repackaging step, it seamlessly pulls the suffixed (isolated) files from the buildroot and automatically strips the package name suffix before finalizing the RPM payload. This guarantees that subpackages retain their distinct, original binaries, restoring full support for overlapping paths.

## Tested

Tested on Tumbleweed container.