### PR TITLE
debian: skip shellcheck on i386

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: pesign-obs-integration
 Section: devel
 Priority: optional
 Maintainer: Michal Marek <mmarek@suse.cz>
-Build-Depends: debhelper (>= 7), openssl, shellcheck
+Build-Depends: debhelper (>= 7), openssl, shellcheck [!i386]
 Standards-Version: 3.9.8
 
 Package: pesign-obs-integration

--- a/debian/rules
+++ b/debian/rules
@@ -25,4 +25,7 @@ override_dh_install:
 	fi
 
 override_dh_auto_test:
-	shellcheck dh_signobs
+	# shellcheck is not available anymore on Ubuntu i386
+	if command -v shellcheck >/dev/null; then \
+		shellcheck dh_signobs; \
+	fi


### PR DESCRIPTION
Ubuntu no longer ships shellcheck for i386, so skip it if not available